### PR TITLE
CPP compilation excludes redundant code submission file, fixes codewit-us/codewit.us#152

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ curl -X POST http://localhost:3000/execute \
 -H "Content-Type: application/json" \
 -d '{
     "language": "cpp",
-    "code": "int add(int a, int b) { return a + b; }\n",                                  
+    "code": "#include <iostream>\nusing namespace std;\nint main(){\ncout<<\"Hola!\n\";\nreturn 0;\n}\n",                                  
     "runTests": true,
-    "testCode": "extern int add(int a, int b);\n#include <cxxtest/TestSuite.h>\n\nclass AddTestSuite : public CxxTest::TestSuite {\npublic:\n    void testAddPositiveNumbers() { TS_ASSERT_EQUALS(add(2, 3), 5); }\n    void testAddNegativeNumbers() { TS_ASSERT_EQUALS(add(-1, 1), 0); }\n};"
+    "testCode": "#include <cxxtest/TestSuite.h>\n#include <sstream>\n#include <iostream>\n#define main program_main\n#include \"program.cpp\"\n#undef main\nclass codewit_test : public CxxTest::TestSuite {\npublic:\nvoid testHolaMundo(){\nstd::stringstream out;\nstd::streambuf* cout_buf = std::cout.rdbuf();\nstd::cout.rdbuf(out.rdbuf());\nprogram_main();\nstd::cout.rdbuf(cout_buf);\nTS_ASSERT_EQUALS(\"Hola!\n\",out.str());}};\n"
 }'
 ```
 

--- a/codeeval.http
+++ b/codeeval.http
@@ -33,9 +33,9 @@ Cookie: connect.sid=suhvferkuhvikerv
 
 {
     "language": "cpp",
-    "code": "int add(int a, int b) { return a + b; }\n",                                  
+    "code": "#include <iostream>\nusing namespace std;\nint main(){\ncout<<\"Hola!\n\";\nreturn 0;\n}\n",                                  
     "runTests": true,
-    "testCode": "extern int add(int a, int b);\n#include <cxxtest/TestSuite.h>\n\nclass AddTestSuite : public CxxTest::TestSuite {\npublic:\n    void testAddPositiveNumbers() { TS_ASSERT_EQUALS(add(2, 3), 5); }\n    void testAddNegativeNumbers() { TS_ASSERT_EQUALS(add(-1, 1), 0); }\n};"
+    "testCode": "#include <cxxtest/TestSuite.h>\n#include <sstream>\n#include <iostream>\n#define main program_main\n#include \"program.cpp\"\n#undef main\nclass codewit_test : public CxxTest::TestSuite {\npublic:\nvoid testHolaMundo(){\nstd::stringstream out;\nstd::streambuf* cout_buf = std::cout.rdbuf();\nstd::cout.rdbuf(out.rdbuf());\nprogram_main();\nstd::cout.rdbuf(cout_buf);\nTS_ASSERT_EQUALS(\"Hola!\n\",out.str());}};\n"
 }
 
 ###

--- a/executor.js
+++ b/executor.js
@@ -154,7 +154,6 @@ async function generateCppTestRunner(uniqueDir) {
   const testHeaderPath = path.join(uniqueDir, 'test_program.h');
   const runnerCppPath = path.join(uniqueDir, 'runner.cpp');
   const runnerExecutablePath = path.join(uniqueDir, 'runner');
-  const mainCppPath = path.join(uniqueDir, 'program.cpp');
 
   await compileCode('cxxtestgen', ['--error-printer', '-o', runnerCppPath, testHeaderPath], uniqueDir);
   await compileCode('g++', ['-std=c++20', '-o', runnerExecutablePath, runnerCppPath], uniqueDir);


### PR DESCRIPTION
Trying to compile `runner.cpp` *and* `program.cpp` results in function redefinition errors since `program.cpp` is already included when the previous `cxxtestgen` command is run.

Please check this PR thoroughly because this is a quick patch that I have not given due diligence to testing, but I wanted to offer the fix while it's fresh on my mind.