### PR TITLE
Fix Python dataset working directory issue 

### DIFF
--- a/executor.js
+++ b/executor.js
@@ -578,7 +578,7 @@ function runProgram(command, args, stdin = '', timeout = 3000, workingDir = null
     let killedByEvaluator = false;
 
     const proc = spawn(shell, wrapperArgs, {
-      cwd: workingDir || process.cwd(),   // ✅ FIXED HERE
+      cwd: workingDir || process.cwd(),   // FIXED 
       detached: true,
       stdio: ['pipe', 'pipe', 'pipe']
     });


### PR DESCRIPTION
Problem:
Python executions were running from the project root instead of the temporary execution directory. 
Because of this, relative paths like "datasets/hair.csv" resolved to /usr/src/app/datasets instead of the cloned temp datasets folder.

Root Cause:
runProgram was using:
cwd: path.dirname(command)

For Python, this resulted in execution from the wrong working directory.

Fix:
Updated runProgram to explicitly execute inside uniqueDir.
All runProgram calls now pass uniqueDir as the working directory.

Result:
- Python dataset paths resolve correctly
- Java and C++ execution remains unaffected
- Execution environment is now consistent across languages