### PR TITLE
Install pandas in the Docker image for dataset-based Python exercises

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /usr/src/app
 
 COPY package*.json ./
 
-RUN npm install && pip3 install --no-cache-dir pytest
+RUN npm install && pip3 install --no-cache-dir pytest pandas
 
 RUN mkdir lib
 


### PR DESCRIPTION
Adds `pandas` to the `codeeval` Docker image so Python exercises that read CSV datasets can run inside the container.

Fixes #18 