### PR TITLE
fix(cpp): support CxxTest main signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,29 +99,20 @@ curl -X POST http://localhost:3000/execute \
 -H "Content-Type: application/json" \
 -d '{
     "language": "cpp",
-    "code": "#include <iostream>\nusing namespace std;\nint main(){\ncout<<\"Hola!\n\";\nreturn 0;\n}\n",                                  
+    "code": "int main(int argc, char** argv) { return argc; }",
     "runTests": true,
-    "testCode": "#include <cxxtest/TestSuite.h>\n#include <sstream>\n#include <iostream>\n#define main program_main\n#include \"program.cpp\"\n#undef main\nclass codewit_test : public CxxTest::TestSuite {\npublic:\nvoid testHolaMundo(){\nstd::stringstream out;\nstd::streambuf* cout_buf = std::cout.rdbuf();\nstd::cout.rdbuf(out.rdbuf());\nprogram_main();\nstd::cout.rdbuf(cout_buf);\nTS_ASSERT_EQUALS(\"Hola!\n\",out.str());}};\n"
+    "testCode": "#include <cxxtest/TestSuite.h>\nclass codewit_test : public CxxTest::TestSuite {\npublic:\nvoid testMain(){ TS_ASSERT_EQUALS(program_main(), 0); }\n};"
 }'
 ```
 
-The legacy C++ fixture above remains supported. New fixtures can omit the
-`program.cpp` include; the evaluator includes the submission and exposes
-`program_main()` for either `int main()` or `int main(int, char**)`:
+The evaluator includes `program.cpp` for this fixture and exposes
+`program_main()`. It supports the standard C++ entry-point forms `int main()`,
+`int main(void)`, `int main(int, char**)`, and `int main(int, char*[])`.
 
-```cpp
-#include <cxxtest/TestSuite.h>
-
-class codewit_test : public CxxTest::TestSuite {
-public:
-  void testMain() {
-    TS_ASSERT_EQUALS(program_main(), 0);
-  }
-};
-```
-
-For an `int main(int argc, char** argv)` submission, `program_main()` invokes
-the program with an empty argument list.
+For an argc/argv submission, `program_main()` invokes the program with an
+empty argument list. The legacy self-including fixture form using
+`#define main program_main` and `#include "program.cpp"` also remains
+supported.
 
 - Java
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,24 @@ curl -X POST http://localhost:3000/execute \
 }'
 ```
 
+The legacy C++ fixture above remains supported. New fixtures can omit the
+`program.cpp` include; the evaluator includes the submission and exposes
+`program_main()` for either `int main()` or `int main(int, char**)`:
+
+```cpp
+#include <cxxtest/TestSuite.h>
+
+class codewit_test : public CxxTest::TestSuite {
+public:
+  void testMain() {
+    TS_ASSERT_EQUALS(program_main(), 0);
+  }
+};
+```
+
+For an `int main(int argc, char** argv)` submission, `program_main()` invokes
+the program with an empty argument list.
+
 - Java
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ curl -X POST http://localhost:3000/execute \
 -H "Content-Type: application/json" \
 -d '{
     "language": "cpp",
-    "code": "int main(int argc, char** argv) { return argc; }",
+    "code": "#include <iostream>\nint main(int argc, char** argv) { std::cout << \"Hello, CodeEval!\\n\"; return argc; }",
     "runTests": true,
-    "testCode": "#include <cxxtest/TestSuite.h>\nclass codewit_test : public CxxTest::TestSuite {\npublic:\nvoid testMain(){ TS_ASSERT_EQUALS(program_main(), 0); }\n};"
+    "testCode": "#include <cxxtest/TestSuite.h>\n#include <iostream>\n#include <sstream>\nclass codewit_test : public CxxTest::TestSuite {\npublic:\nvoid testMainOutput(){\nstd::ostringstream output;\nstd::streambuf* original = std::cout.rdbuf(output.rdbuf());\nint exitCode = program_main();\nstd::cout.rdbuf(original);\nTS_ASSERT_EQUALS(exitCode, 0);\nTS_ASSERT_EQUALS(output.str(), \"Hello, CodeEval!\\n\");\n}\n};"
 }'
 ```
 

--- a/codeeval.http
+++ b/codeeval.http
@@ -17,6 +17,19 @@ Content-Type: application/json
 Cookie: connect.sid=suhvferkuhvikerv
 
 {
+    "language": "cpp",
+    "code": "int main(int argc, char** argv) { return argc; }",
+    "runTests": true,
+    "testCode": "#include <cxxtest/TestSuite.h>\nclass codewit_test : public CxxTest::TestSuite {\npublic:\nvoid testMain(){ TS_ASSERT_EQUALS(program_main(), 0); }\n};"
+}
+
+###
+
+POST http://localhost:3000/execute
+Content-Type: application/json
+Cookie: connect.sid=suhvferkuhvikerv
+
+{
     "language": "java",
     "code": "public class Main {\n    public static void main(String[] args) {\n        System.out.println(\"Hello, World!\");\n    }\n}",
     "stdin": "",

--- a/executor.js
+++ b/executor.js
@@ -178,22 +178,12 @@ function testCodeIncludesProgramSource(testCode) {
   return /^\s*#\s*include\s*[<"]program\.cpp[>"]/m.test(testCode);
 }
 
-function detectCppMainSignature(cppCode) {
+function sourceContainsCppMain(cppCode) {
   const source = cppCode.replace(
     /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*/g,
     ' '
   );
-  const match = source.match(/\bint\s+main\s*\(([^)]*)\)\s*\{/);
-
-  if (!match) return null;
-
-  const parameters = match[1].trim();
-  if (!parameters || parameters === 'void') return 'noArguments';
-
-  const hasIntegerArgument = /\bint\b/.test(parameters);
-  const hasCharacterPointerArray = /\bchar\s*\*\s*\*(?:\s*[A-Za-z_]\w*)?|\bchar\s*\*\s*[A-Za-z_]\w*\s*\[\s*\]/.test(parameters);
-
-  return hasIntegerArgument && hasCharacterPointerArray ? 'arguments' : null;
+  return /\bmain\s*\(/.test(source);
 }
 
 function buildCppTestHeader(studentCode, testCode) {
@@ -202,12 +192,25 @@ function buildCppTestHeader(studentCode, testCode) {
     return [declarations, testCode].filter(Boolean).join('\n\n');
   }
 
-  const mainSignature = detectCppMainSignature(studentCode);
-  const adapter = mainSignature === 'noArguments'
-    ? 'inline int program_main() { return codeval_student_main(); }'
-    : mainSignature === 'arguments'
-      ? 'inline int program_main() { return codeval_student_main(0, nullptr); }'
-      : '';
+  const adapter = sourceContainsCppMain(studentCode)
+    ? `#include <type_traits>
+
+template <typename EntryPoint>
+int codeval_invoke_main(EntryPoint entryPoint) {
+  if constexpr (std::is_invocable_v<EntryPoint>) {
+    return entryPoint();
+  } else if constexpr (std::is_invocable_v<EntryPoint, int, char**>) {
+    return entryPoint(0, nullptr);
+  } else {
+    static_assert(std::is_invocable_v<EntryPoint>, "Unsupported main signature");
+    return 1;
+  }
+}
+
+inline int program_main() {
+  return codeval_invoke_main(codeval_student_main);
+}`
+    : '';
 
   return [
     '#define main codeval_student_main',

--- a/executor.js
+++ b/executor.js
@@ -166,8 +166,56 @@ function extractFunctionDeclarations(cppCode) {
   const matches = cppCode.match(regex);
   if (!matches) return '';
 
-  // Turn function definitions into declarations by adding semicolons
-  return matches.map(fn => fn.trim() + ';').join('\n');
+  // CxxTest generates the runner entry point, so the student's main must not
+  // be declared in the generated test header.
+  return matches
+    .filter((fn) => !/\bmain\s*\(/.test(fn))
+    .map((fn) => fn.trim() + ';')
+    .join('\n');
+}
+
+function testCodeIncludesProgramSource(testCode) {
+  return /^\s*#\s*include\s*[<"]program\.cpp[>"]/m.test(testCode);
+}
+
+function detectCppMainSignature(cppCode) {
+  const source = cppCode.replace(
+    /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*/g,
+    ' '
+  );
+  const match = source.match(/\bint\s+main\s*\(([^)]*)\)\s*\{/);
+
+  if (!match) return null;
+
+  const parameters = match[1].trim();
+  if (!parameters || parameters === 'void') return 'noArguments';
+
+  const hasIntegerArgument = /\bint\b/.test(parameters);
+  const hasCharacterPointerArray = /\bchar\s*\*\s*\*(?:\s*[A-Za-z_]\w*)?|\bchar\s*\*\s*[A-Za-z_]\w*\s*\[\s*\]/.test(parameters);
+
+  return hasIntegerArgument && hasCharacterPointerArray ? 'arguments' : null;
+}
+
+function buildCppTestHeader(studentCode, testCode) {
+  if (testCodeIncludesProgramSource(testCode)) {
+    const declarations = extractFunctionDeclarations(studentCode);
+    return [declarations, testCode].filter(Boolean).join('\n\n');
+  }
+
+  const mainSignature = detectCppMainSignature(studentCode);
+  const adapter = mainSignature === 'noArguments'
+    ? 'inline int program_main() { return codeval_student_main(); }'
+    : mainSignature === 'arguments'
+      ? 'inline int program_main() { return codeval_student_main(0, nullptr); }'
+      : '';
+
+  return [
+    '#define main codeval_student_main',
+    '#include "program.cpp"',
+    '#undef main',
+    adapter,
+    testCode,
+  ].filter(Boolean).join('\n\n');
 }
 
 /**
@@ -192,13 +240,7 @@ async function handleTestSetup(language, uniqueDir, className, testCode) {
       const programCppPath = path.join(uniqueDir, 'program.cpp');
       const studentCode = await fs.readFile(programCppPath, 'utf-8');
 
-      const declarations = extractFunctionDeclarations(studentCode);
-
-      const finalTestCode = `
-${declarations}
-
-${testCode}
-      `.trim();
+      const finalTestCode = buildCppTestHeader(studentCode, testCode);
 
       await fs.writeFile(path.join(uniqueDir, 'test_program.h'), finalTestCode);
       await generateCppTestRunner(uniqueDir);
@@ -762,4 +804,4 @@ async function cleanupDir(dirPath) {
   }
 }
 
-module.exports = { executeCode };
+module.exports = { buildCppTestHeader, executeCode };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "node test/cpp-harness.test.js && node test/cpp-harness-smoke.test.js"
+    "test": "node test/cpp-harness.test.js && node test/cpp-harness-smoke.test.js && node test/executor-response.test.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/cpp-harness.test.js && node test/cpp-harness-smoke.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/cpp-harness-smoke.test.js
+++ b/test/cpp-harness-smoke.test.js
@@ -39,12 +39,30 @@ public:
 };
 `;
 
+const outputFixture = `
+#include <cxxtest/TestSuite.h>
+#include <iostream>
+#include <sstream>
+class OutputCppHarnessTest : public CxxTest::TestSuite {
+public:
+  void testProgramMainOutput() {
+    std::ostringstream output;
+    std::streambuf* original = std::cout.rdbuf(output.rdbuf());
+    int exitCode = program_main();
+    std::cout.rdbuf(original);
+    TS_ASSERT_EQUALS(exitCode, 0);
+    TS_ASSERT_EQUALS(output.str(), "Hello, CodeEval!\\n");
+  }
+};
+`;
+
 const cases = [
   ['no-argument main', 'int main() { return 0; }', fixture],
   ['void main', 'int main(void) { return 0; }', fixture],
   ['argument main', 'int main(int argc, char** argv) { return argc; }', fixture],
   ['unnamed argument main', 'int main(int, char**) { return 0; }', fixture],
   ['array argument main', 'int main(int argc, char* argv[]) { return argc; }', fixture],
+  ['captured standard output', '#include <iostream>\nint main(int argc, char** argv) { std::cout << "Hello, CodeEval!\\n"; return argc; }', outputFixture],
   ['legacy fixture', 'int main() { return 0; }', legacyFixture],
 ];
 

--- a/test/cpp-harness-smoke.test.js
+++ b/test/cpp-harness-smoke.test.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const { buildCppTestHeader } = require('../executor');
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  assert.ifError(result.error);
+  assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+}
+
+if (spawnSync('cxxtestgen', ['--version'], { encoding: 'utf8' }).error) {
+  console.log('Skipped C++ CxxTest smoke tests: cxxtestgen is unavailable.');
+  process.exit(0);
+}
+
+const fixture = `
+#include <cxxtest/TestSuite.h>
+class CppHarnessTest : public CxxTest::TestSuite {
+public:
+  void testProgramMain() {
+    TS_ASSERT_EQUALS(program_main(), 0);
+  }
+};
+`;
+
+const legacyFixture = `
+#include <cxxtest/TestSuite.h>
+#define main program_main
+#include "program.cpp"
+#undef main
+class LegacyCppHarnessTest : public CxxTest::TestSuite {
+public:
+  void testProgramMain() {
+    TS_ASSERT_EQUALS(program_main(), 0);
+  }
+};
+`;
+
+const cases = [
+  ['no-argument main', 'int main() { return 0; }', fixture],
+  ['void main', 'int main(void) { return 0; }', fixture],
+  ['argument main', 'int main(int argc, char** argv) { return argc; }', fixture],
+  ['unnamed argument main', 'int main(int, char**) { return 0; }', fixture],
+  ['array argument main', 'int main(int argc, char* argv[]) { return argc; }', fixture],
+  ['legacy fixture', 'int main() { return 0; }', legacyFixture],
+];
+
+async function runCase([name, program, testCode]) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'codeval-cpp-harness-'));
+
+  try {
+    await fs.writeFile(path.join(directory, 'program.cpp'), program);
+    await fs.writeFile(
+      path.join(directory, 'test_program.h'),
+      buildCppTestHeader(program, testCode)
+    );
+    run('cxxtestgen', ['--error-printer', '-o', 'runner.cpp', 'test_program.h'], directory);
+    run('g++', ['-std=c++20', '-o', 'runner', 'runner.cpp'], directory);
+    run(path.join(directory, 'runner'), [], directory);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+
+  console.log(`Passed C++ CxxTest smoke test: ${name}.`);
+}
+
+Promise.all(cases.map(runCase)).catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/cpp-harness.test.js
+++ b/test/cpp-harness.test.js
@@ -24,21 +24,21 @@ assert.ok(legacyHeader.includes(legacyFixture.trim()));
 
 const noArgumentHeader = buildCppTestHeader(noArgumentMain, harnessFixture);
 assert.ok(noArgumentHeader.includes('#define main codeval_student_main'));
-assert.ok(noArgumentHeader.includes('return codeval_student_main();'));
+assert.ok(noArgumentHeader.includes('return codeval_invoke_main(codeval_student_main);'));
 assert.ok(!noArgumentHeader.includes('int main();'));
 
 const voidHeader = buildCppTestHeader(voidMain, harnessFixture);
-assert.ok(voidHeader.includes('return codeval_student_main();'));
+assert.ok(voidHeader.includes('std::is_invocable_v<EntryPoint>'));
 
 const argumentHeader = buildCppTestHeader(argumentMain, harnessFixture);
-assert.ok(argumentHeader.includes('return codeval_student_main(0, nullptr);'));
+assert.ok(argumentHeader.includes('std::is_invocable_v<EntryPoint, int, char**>'));
 assert.ok(!argumentHeader.includes('int main(int argc, char** argv);'));
 
 const unnamedArgumentHeader = buildCppTestHeader(unnamedArgumentMain, harnessFixture);
-assert.ok(unnamedArgumentHeader.includes('return codeval_student_main(0, nullptr);'));
+assert.ok(unnamedArgumentHeader.includes('return entryPoint(0, nullptr);'));
 
 const arrayArgumentHeader = buildCppTestHeader(arrayArgumentMain, harnessFixture);
-assert.ok(arrayArgumentHeader.includes('return codeval_student_main(0, nullptr);'));
+assert.ok(arrayArgumentHeader.includes('return entryPoint(0, nullptr);'));
 
 const noMainHeader = buildCppTestHeader(noMain, harnessFixture);
 assert.ok(noMainHeader.includes('#include "program.cpp"'));

--- a/test/cpp-harness.test.js
+++ b/test/cpp-harness.test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const { buildCppTestHeader } = require('../executor');
+
+const legacyFixture = `
+#include <cxxtest/TestSuite.h>
+#define main program_main
+#include "program.cpp"
+#undef main
+class LegacyTest : public CxxTest::TestSuite {};
+`;
+
+const noArgumentMain = 'int add(int a, int b) { return a + b; }\nint main() { return add(2, 3); }';
+const voidMain = 'int main(void) { return 0; }';
+const argumentMain = 'int main(int argc, char** argv) { return argc; }';
+const unnamedArgumentMain = 'int main(int, char**) { return 0; }';
+const arrayArgumentMain = 'int main(int argc, char* argv[]) { return argc; }';
+const noMain = 'int add(int a, int b) { return a + b; }';
+const harnessFixture = '#include <cxxtest/TestSuite.h>\nclass HarnessTest : public CxxTest::TestSuite {};';
+
+const legacyHeader = buildCppTestHeader(noArgumentMain, legacyFixture);
+assert.ok(legacyHeader.includes('int add(int a, int b);'));
+assert.ok(!legacyHeader.includes('int main();'));
+assert.ok(legacyHeader.includes(legacyFixture.trim()));
+
+const noArgumentHeader = buildCppTestHeader(noArgumentMain, harnessFixture);
+assert.ok(noArgumentHeader.includes('#define main codeval_student_main'));
+assert.ok(noArgumentHeader.includes('return codeval_student_main();'));
+assert.ok(!noArgumentHeader.includes('int main();'));
+
+const voidHeader = buildCppTestHeader(voidMain, harnessFixture);
+assert.ok(voidHeader.includes('return codeval_student_main();'));
+
+const argumentHeader = buildCppTestHeader(argumentMain, harnessFixture);
+assert.ok(argumentHeader.includes('return codeval_student_main(0, nullptr);'));
+assert.ok(!argumentHeader.includes('int main(int argc, char** argv);'));
+
+const unnamedArgumentHeader = buildCppTestHeader(unnamedArgumentMain, harnessFixture);
+assert.ok(unnamedArgumentHeader.includes('return codeval_student_main(0, nullptr);'));
+
+const arrayArgumentHeader = buildCppTestHeader(arrayArgumentMain, harnessFixture);
+assert.ok(arrayArgumentHeader.includes('return codeval_student_main(0, nullptr);'));
+
+const noMainHeader = buildCppTestHeader(noMain, harnessFixture);
+assert.ok(noMainHeader.includes('#include "program.cpp"'));
+assert.ok(!noMainHeader.includes('inline int program_main()'));
+
+const commentedMainHeader = buildCppTestHeader('// int main() { return 0; }', harnessFixture);
+assert.ok(!commentedMainHeader.includes('inline int program_main()'));
+
+const stringMainHeader = buildCppTestHeader('const char* text = "int main() { return 0; }";', harnessFixture);
+assert.ok(!stringMainHeader.includes('inline int program_main()'));
+
+console.log('Passed C++ CxxTest harness regression tests.');

--- a/test/executor-response.test.js
+++ b/test/executor-response.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { executeCode } = require('../executor');
+
+if (process.env.RUN_EXECUTOR_INTEGRATION !== 'true') {
+  console.log('Skipped executor response integration test.');
+  process.exit(0);
+}
+
+process.env.ENABLE_CPP = 'true';
+
+executeCode('cpp', 'int main( { return 0; }', '', '', false)
+  .then((response) => {
+    assert.strictEqual(response.state, 'compile_error');
+    assert.ok(response.compilation_error);
+    assert.strictEqual(response.runtime_error, '');
+    assert.strictEqual(response.tests_run, 0);
+    console.log('Passed compilation-error response integration test.');
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary

- prevent CxxTest headers from declaring a submitted C++ main
- preserve legacy fixtures that include program.cpp themselves
- add harness fixtures that expose program_main() for no-argument and argc/argv main signatures
- document the simplified fixture style and add an argc/argv request sample

## Verification

- npm test (unit suite; CxxTest smoke tests skip locally because cxxtestgen is unavailable)
- docker build -t codeval-cpp-main-signatures .
- docker run --rm codeval-cpp-main-signatures npm test

The Docker smoke suite compiles and runs no-argument, void, named and unnamed argc/argv, array argv, and legacy fixture cases.

Closes #26