### PR TITLE
fix(cpp): classify CxxTest failures correctly

### DIFF
--- a/executor.js
+++ b/executor.js
@@ -433,7 +433,7 @@ function parseCppTestOutput(output, stdout = '', stderr = '') {
       total_tests = parseInt(totalMatch[1]);
   }
 
-  const failedMatch = output.match(/Failed (\d+) and Skipped \d+ of (\d+) tests/);
+  const failedMatch = output.match(/Failed (\d+) and Skipped \d+ of (\d+) tests?/);
   if (failedMatch) {
       failed_tests = parseInt(failedMatch[1]);
       total_tests = parseInt(failedMatch[2]);
@@ -450,7 +450,7 @@ function parseCppTestOutput(output, stdout = '', stderr = '') {
       test_case: `Test ${index + 1}`,
       expected: expectedExpr,
       received: receivedValue,
-      error_message: "AssertionError: Output did not match expected result",
+      error_message: `AssertionError: ${match[0]}`,
       rawout: `${stdout}\n${stderr}`,
       stderr,
     });
@@ -461,6 +461,54 @@ function parseCppTestOutput(output, stdout = '', stderr = '') {
     passed: passed_tests,
     failed: failed_tests,
     failure_details: failures,
+  };
+}
+
+function buildCppTestResponse(response, output) {
+  const stdout = output.stdout || '';
+  const stderr = output.stderr || '';
+  const testResults = parseCppTestOutput(stdout, stdout, stderr);
+  const failureDetails = [...testResults.failure_details];
+  const runnerFailed = (output.exitCode != null && output.exitCode !== 0) || Boolean(response.runtime_error);
+  let failed = Math.max(testResults.failed, failureDetails.length);
+  let testsRun = Math.max(testResults.tests_run, failed);
+
+  if (failed > failureDetails.length) {
+    for (let index = failureDetails.length; index < failed; index += 1) {
+      failureDetails.push({
+        test_case: `Test ${index + 1}`,
+        expected: '',
+        received: '',
+        error_message: 'CxxTest assertion failed',
+        rawout: `${stdout}\n${stderr}`,
+        stderr,
+      });
+    }
+  }
+
+  let runtimeError = '';
+  if (runnerFailed && failed === 0) {
+    runtimeError = response.runtime_error || `C++ test runner exited with code ${output.exitCode}`;
+    testsRun = Math.max(testsRun, 1);
+    failed = 1;
+    failureDetails.push({
+      test_case: 'C++ test runner',
+      expected: '',
+      received: '',
+      error_message: runtimeError,
+      rawout: `${stdout}\n${stderr}`,
+      stderr,
+    });
+  }
+
+  return {
+    ...response,
+    tests_run: testsRun,
+    passed: Math.max(0, testsRun - failed),
+    failed,
+    failure_details: failureDetails,
+    runtime_error: runtimeError,
+    state: failed === 0 ? 'passed' : 'failed',
   };
 }
 
@@ -620,10 +668,7 @@ async function executeCode(language, code, stdin, expectedOutput, runTests = fal
       }
 
       if (language.toLowerCase() === 'cpp') {
-        const testResults = parseCppTestOutput(output.stdout || output, output.stdout, output.stderr);
-        response = { ...response, ...testResults };
-        response.state = testResults.failed === 0 ? 'passed' : 'failed';
-        return response;
+        return buildCppTestResponse(response, output);
       }
 
       const stdout = (output.stdout || output).toString();
@@ -807,4 +852,9 @@ async function cleanupDir(dirPath) {
   }
 }
 
-module.exports = { buildCppTestHeader, executeCode };
+module.exports = {
+  buildCppTestHeader,
+  buildCppTestResponse,
+  executeCode,
+  parseCppTestOutput,
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "node test/cpp-harness.test.js && node test/cpp-harness-smoke.test.js && node test/executor-response.test.js"
+    "test": "node test/cpp-harness.test.js && node test/cpp-result.test.js && node test/cpp-harness-smoke.test.js && node test/executor-response.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/cpp-result.test.js
+++ b/test/cpp-result.test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const { buildCppTestResponse, parseCppTestOutput } = require('../executor');
+
+const oneTestFailure = `Running cxxtest tests (1 test)
+test_program.h:15: Error: Expected (expected == "soccer"), found (actual != "hi")
+Failed 1 and Skipped 0 of 1 test`;
+
+const pluralFailure = `Running cxxtest tests (2 tests)
+test_program.h:15: Error: Expected (expected == "soccer"), found (actual != "hi")
+Failed 1 and Skipped 0 of 2 tests`;
+
+for (const [name, output, total] of [
+  ['singular failure summary', oneTestFailure, 1],
+  ['plural failure summary', pluralFailure, 2],
+]) {
+  const result = parseCppTestOutput(output, output, '');
+  assert.strictEqual(result.tests_run, total, name);
+  assert.strictEqual(result.passed, total - 1, name);
+  assert.strictEqual(result.failed, 1, name);
+  assert.ok(result.failure_details[0].error_message.includes('Expected'), name);
+}
+
+const assertionResponse = buildCppTestResponse(
+  { state: 'failed', runtime_error: 'Execution failed with code 1', failure_details: [] },
+  { stdout: oneTestFailure, stderr: '', exitCode: 1 }
+);
+assert.strictEqual(assertionResponse.state, 'failed');
+assert.strictEqual(assertionResponse.runtime_error, '');
+assert.strictEqual(assertionResponse.tests_run, 1);
+assert.strictEqual(assertionResponse.passed, 0);
+assert.strictEqual(assertionResponse.failed, 1);
+assert.strictEqual(assertionResponse.failure_details.length, 1);
+assert.ok(assertionResponse.failure_details[0].rawout.includes('Expected'));
+
+const runnerFailure = buildCppTestResponse(
+  { state: 'failed', runtime_error: 'Execution failed with code 139', failure_details: [] },
+  { stdout: 'segmentation fault', stderr: '', exitCode: 139 }
+);
+assert.strictEqual(runnerFailure.state, 'failed');
+assert.strictEqual(runnerFailure.runtime_error, 'Execution failed with code 139');
+assert.strictEqual(runnerFailure.tests_run, 1);
+assert.strictEqual(runnerFailure.failed, 1);
+assert.strictEqual(runnerFailure.failure_details[0].error_message, 'Execution failed with code 139');
+
+console.log('Passed C++ result classification regression tests.');

--- a/test/executor-response.test.js
+++ b/test/executor-response.test.js
@@ -8,15 +8,62 @@ if (process.env.RUN_EXECUTOR_INTEGRATION !== 'true') {
 
 process.env.ENABLE_CPP = 'true';
 
-executeCode('cpp', 'int main( { return 0; }', '', '', false)
-  .then((response) => {
-    assert.strictEqual(response.state, 'compile_error');
-    assert.ok(response.compilation_error);
-    assert.strictEqual(response.runtime_error, '');
-    assert.strictEqual(response.tests_run, 0);
-    console.log('Passed compilation-error response integration test.');
-  })
-  .catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  });
+const failingCxxTest = `
+#include <cxxtest/TestSuite.h>
+#include <iostream>
+#include <sstream>
+class CppResultTest : public CxxTest::TestSuite {
+public:
+  void testOutput() {
+    std::ostringstream output;
+    std::streambuf* original = std::cout.rdbuf(output.rdbuf());
+    program_main();
+    std::cout.rdbuf(original);
+    TS_ASSERT_EQUALS("expected", output.str());
+  }
+};
+`;
+
+async function run() {
+  const compilationError = await executeCode('cpp', 'int main( { return 0; }', '', '', false);
+  assert.strictEqual(compilationError.state, 'compile_error');
+  assert.ok(compilationError.compilation_error);
+  assert.strictEqual(compilationError.runtime_error, '');
+  assert.strictEqual(compilationError.tests_run, 0);
+
+  const assertionFailure = await executeCode(
+    'cpp',
+    '#include <iostream>\nint main() { std::cout << "actual"; return 0; }',
+    '',
+    '',
+    true,
+    failingCxxTest
+  );
+  assert.strictEqual(assertionFailure.state, 'failed');
+  assert.strictEqual(assertionFailure.tests_run, 1);
+  assert.strictEqual(assertionFailure.passed, 0);
+  assert.strictEqual(assertionFailure.failed, 1);
+  assert.strictEqual(assertionFailure.runtime_error, '');
+  assert.ok(assertionFailure.failure_details[0].error_message.includes('AssertionError'));
+  assert.ok(assertionFailure.failure_details[0].rawout.includes('Expected'));
+
+  const outputMismatch = await executeCode(
+    'cpp',
+    '#include <iostream>\nint main() { std::cout << "actual"; return 0; }',
+    '',
+    'expected',
+    false
+  );
+  assert.strictEqual(outputMismatch.state, 'failed');
+  assert.strictEqual(outputMismatch.compilation_error, '');
+  assert.strictEqual(outputMismatch.runtime_error, '');
+  assert.strictEqual(outputMismatch.failure_details[0].expected, 'expected');
+  assert.strictEqual(outputMismatch.failure_details[0].received, 'actual');
+
+  console.log('Passed compiler, CxxTest, and output-mismatch response integration tests.');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- parse singular and plural CxxTest failure summaries
- classify assertion failures as failed tests instead of generic runtime errors
- prevent nonzero unparseable CxxTest runners from being reported as passed
- keep CxxTest assertion lines visible in failure details
- cover compilation errors, test failures, runner fallback, and normal output mismatches

## API compatibility

No request or response fields are added, removed, or renamed. Compilation errors remain compile_error, assertion failures remain failed evaluations, and valid wrong-output submissions remain failed output checks.

## Verification

- npm test
- docker build -t codeval-cpp-result-classification .
- docker run --rm -e RUN_EXECUTOR_INTEGRATION=true codeval-cpp-result-classification npm test

The Docker suite covers compiler errors, one-test CxxTest assertion failures, standard main forms, a normal output mismatch, and successful C++ tests.

Closes #28