### PR TITLE
fix(cpp): preserve CxxTest assertion diagnostics

### DIFF
--- a/executor.js
+++ b/executor.js
@@ -441,16 +441,13 @@ function parseCppTestOutput(output, stdout = '', stderr = '') {
 
   passed_tests = total_tests - failed_tests;
 
-  const failureMatches = [...output.matchAll(/Error: Expected \((.*?)\), found \((.*?)\)/g)];
-  failureMatches.forEach((match, index) => {
-    const expectedExpr = match[1].split("==")[1]?.trim() || match[1].trim();
-    const receivedValue = match[2].split("!=")[0]?.trim() || match[2].trim();
-
+  const diagnosticBlocks = extractCppDiagnosticBlocks(output);
+  diagnosticBlocks.forEach((message, index) => {
     failures.push({
       test_case: `Test ${index + 1}`,
-      expected: expectedExpr,
-      received: receivedValue,
-      error_message: `AssertionError: ${match[0]}`,
+      expected: '',
+      received: '',
+      error_message: message,
       rawout: `${stdout}\n${stderr}`,
       stderr,
     });
@@ -464,6 +461,46 @@ function parseCppTestOutput(output, stdout = '', stderr = '') {
   };
 }
 
+function extractCppDiagnosticBlocks(output) {
+  const diagnostics = [];
+  let current = [];
+
+  const addCurrent = () => {
+    if (current.length > 0) {
+      diagnostics.push(current.join('\n'));
+      current = [];
+    }
+  };
+
+  for (const line of output.toString().split(/\r?\n/)) {
+    const errorIndex = line.indexOf('Error:');
+    if (errorIndex !== -1) {
+      addCurrent();
+      current = [line.slice(errorIndex)];
+      continue;
+    }
+
+    if (current.length > 0 && line && !/^(Running cxxtest tests|In .+?:|Failed \d+ and Skipped|Success rate:)/.test(line)) {
+      current.push(line);
+    } else {
+      addCurrent();
+    }
+  }
+
+  addCurrent();
+  return diagnostics;
+}
+
+function extractCppFailureFallback(stdout, stderr) {
+  const output = `${stdout}\n${stderr}`;
+  const relevantLines = output
+    .split(/\r?\n/)
+    .filter((line) => line.includes('Error:') || /^Failed \d+ and Skipped/.test(line));
+  const message = (relevantLines.join('\n') || output.trim()).slice(0, 4096);
+
+  return message || 'CxxTest reported a failed test without a diagnostic message';
+}
+
 function buildCppTestResponse(response, output) {
   const stdout = output.stdout || '';
   const stderr = output.stderr || '';
@@ -473,17 +510,15 @@ function buildCppTestResponse(response, output) {
   let failed = Math.max(testResults.failed, failureDetails.length);
   let testsRun = Math.max(testResults.tests_run, failed);
 
-  if (failed > failureDetails.length) {
-    for (let index = failureDetails.length; index < failed; index += 1) {
-      failureDetails.push({
-        test_case: `Test ${index + 1}`,
-        expected: '',
-        received: '',
-        error_message: 'CxxTest assertion failed',
-        rawout: `${stdout}\n${stderr}`,
-        stderr,
-      });
-    }
+  if (failed > 0 && failureDetails.length === 0) {
+    failureDetails.push({
+      test_case: 'CxxTest',
+      expected: '',
+      received: '',
+      error_message: extractCppFailureFallback(stdout, stderr),
+      rawout: `${stdout}\n${stderr}`,
+      stderr,
+    });
   }
 
   let runtimeError = '';

--- a/test/cpp-result.test.js
+++ b/test/cpp-result.test.js
@@ -9,6 +9,15 @@ const pluralFailure = `Running cxxtest tests (2 tests)
 test_program.h:15: Error: Expected (expected == "soccer"), found (actual != "hi")
 Failed 1 and Skipped 0 of 2 tests`;
 
+const assertionFailure = `Running cxxtest tests (1 test)
+test_program.h:15: Error: Assertion failed: false
+Failed 1 and Skipped 0 of 1 test`;
+
+const multipleDiagnostics = `Running cxxtest tests (2 tests)
+test_program.h:15: Error: Assertion failed: first student-facing message
+test_program.h:16: Error: Assertion failed: second student-facing message
+Failed 1 and Skipped 0 of 2 tests`;
+
 for (const [name, output, total] of [
   ['singular failure summary', oneTestFailure, 1],
   ['plural failure summary', pluralFailure, 2],
@@ -17,8 +26,26 @@ for (const [name, output, total] of [
   assert.strictEqual(result.tests_run, total, name);
   assert.strictEqual(result.passed, total - 1, name);
   assert.strictEqual(result.failed, 1, name);
-  assert.ok(result.failure_details[0].error_message.includes('Expected'), name);
+  assert.strictEqual(
+    result.failure_details[0].error_message,
+    'Error: Expected (expected == "soccer"), found (actual != "hi")',
+    name
+  );
 }
+
+const assertionResult = parseCppTestOutput(assertionFailure, assertionFailure, '');
+assert.strictEqual(assertionResult.failure_details[0].error_message, 'Error: Assertion failed: false');
+
+const multipleDiagnosticsResult = parseCppTestOutput(multipleDiagnostics, multipleDiagnostics, '');
+assert.strictEqual(multipleDiagnosticsResult.failed, 1);
+assert.strictEqual(multipleDiagnosticsResult.failure_details.length, 2);
+assert.deepStrictEqual(
+  multipleDiagnosticsResult.failure_details.map((failure) => failure.error_message),
+  [
+    'Error: Assertion failed: first student-facing message',
+    'Error: Assertion failed: second student-facing message',
+  ]
+);
 
 const assertionResponse = buildCppTestResponse(
   { state: 'failed', runtime_error: 'Execution failed with code 1', failure_details: [] },
@@ -30,7 +57,16 @@ assert.strictEqual(assertionResponse.tests_run, 1);
 assert.strictEqual(assertionResponse.passed, 0);
 assert.strictEqual(assertionResponse.failed, 1);
 assert.strictEqual(assertionResponse.failure_details.length, 1);
-assert.ok(assertionResponse.failure_details[0].rawout.includes('Expected'));
+assert.strictEqual(
+  assertionResponse.failure_details[0].error_message,
+  'Error: Expected (expected == "soccer"), found (actual != "hi")'
+);
+
+const summaryOnlyFailure = buildCppTestResponse(
+  { state: 'failed', runtime_error: 'Execution failed with code 1', failure_details: [] },
+  { stdout: 'Running cxxtest tests (1 test)\nFailed 1 and Skipped 0 of 1 test', stderr: '', exitCode: 1 }
+);
+assert.strictEqual(summaryOnlyFailure.failure_details[0].error_message, 'Failed 1 and Skipped 0 of 1 test');
 
 const runnerFailure = buildCppTestResponse(
   { state: 'failed', runtime_error: 'Execution failed with code 139', failure_details: [] },

--- a/test/executor-response.test.js
+++ b/test/executor-response.test.js
@@ -24,6 +24,16 @@ public:
 };
 `;
 
+const genericAssertionTest = `
+#include <cxxtest/TestSuite.h>
+class GenericAssertionTest : public CxxTest::TestSuite {
+public:
+  void testStudentGuidance() {
+    TS_ASSERT(false);
+  }
+};
+`;
+
 async function run() {
   const compilationError = await executeCode('cpp', 'int main( { return 0; }', '', '', false);
   assert.strictEqual(compilationError.state, 'compile_error');
@@ -44,8 +54,19 @@ async function run() {
   assert.strictEqual(assertionFailure.passed, 0);
   assert.strictEqual(assertionFailure.failed, 1);
   assert.strictEqual(assertionFailure.runtime_error, '');
-  assert.ok(assertionFailure.failure_details[0].error_message.includes('AssertionError'));
-  assert.ok(assertionFailure.failure_details[0].rawout.includes('Expected'));
+  assert.ok(assertionFailure.failure_details[0].error_message.startsWith('Error: Expected'));
+
+  const genericAssertionFailure = await executeCode(
+    'cpp',
+    'int main() { return 0; }',
+    '',
+    '',
+    true,
+    genericAssertionTest
+  );
+  assert.strictEqual(genericAssertionFailure.state, 'failed');
+  assert.strictEqual(genericAssertionFailure.failed, 1);
+  assert.ok(genericAssertionFailure.failure_details[0].error_message.startsWith('Error: Assertion failed:'));
 
   const outputMismatch = await executeCode(
     'cpp',


### PR DESCRIPTION
## Summary

- preserve CxxTest Error diagnostic blocks in student-visible failure details
- support generic assertions such as TS_ASSERT(false), not only Expected/found comparisons
- retain test-level summary counts and the existing result API contract
- add parser and real CxxTest 4.4 integration regressions

## Verification

- npm test
- docker build -t codeval-cpp-assertion-diagnostics .
- docker run --rm -e RUN_EXECUTOR_INTEGRATION=true codeval-cpp-assertion-diagnostics npm test

Follow-up to #28, whose classification fix has already merged.